### PR TITLE
Add function to remove stop words from sentence

### DIFF
--- a/filter.py
+++ b/filter.py
@@ -1,0 +1,12 @@
+from nltk.corpus import stopwords 
+from nltk.tokenize import word_tokenize
+
+def removeStopWords(sentence):
+    words = word_tokenize(sentence)
+    stopWords = set(stopwords.words('english'))
+    newWords = [word for word in words if not word in stopWords]
+    return newWords
+
+def extractUselessWords(words):
+    #handle removal of useless words
+


### PR DESCRIPTION
Add a function that eliminates stop words like a, an, if, for, etc., from the sentence provided as input. Doing so we can focus on the "meaning" of the sentence rather than its form.